### PR TITLE
Fix isSamePerson check

### DIFF
--- a/src/main/java/seedu/address/model/person/Github.java
+++ b/src/main/java/seedu/address/model/person/Github.java
@@ -52,6 +52,12 @@ public class Github {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true is the Github ID is empty.
+     */
+    public boolean isEmpty() {
+        return githubId.isEmpty();
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -69,6 +69,9 @@ public class Person {
         if (otherPerson == this) {
             return true;
         }
+        if (otherPerson == null) {
+            return false;
+        }
 
         boolean isEmailEqual = otherPerson.getEmail().equals(getEmail());
         boolean isPhoneEqual = otherPerson.getPhone().equals(getPhone());
@@ -80,8 +83,7 @@ public class Person {
         boolean isGithubNonEmptyAndEqual = isBothGithubNonEmpty && otherPerson.getGithub().equals(getGithub());
 
 
-        return otherPerson != null
-                && (isEmailEqual
+        return (isEmailEqual
                 || isPhoneEqual
                 || isTelegramNonEmptyAndEqual
                 || isGithubNonEmptyAndEqual);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -61,7 +61,8 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same Email, Phone, Telegram (non-empty), and Github (non-empty).
+     * Persons are allowed to have the same name.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -69,11 +70,21 @@ public class Person {
             return true;
         }
 
+        boolean isEmailEqual = otherPerson.getEmail().equals(getEmail());
+        boolean isPhoneEqual = otherPerson.getPhone().equals(getPhone());
+        boolean isBothTelegramNonEmpty = !getTelegram().orElse(Telegram.EMPTY).isEmpty()
+                && !otherPerson.getTelegram().orElse(Telegram.EMPTY).isEmpty();
+        boolean isBothGithubNonEmpty = !getGithub().orElse(Github.EMPTY).isEmpty()
+                && !otherPerson.getGithub().orElse(Github.EMPTY).isEmpty();
+        boolean isTelegramNonEmptyAndEqual = isBothTelegramNonEmpty && otherPerson.getTelegram().equals(getTelegram());
+        boolean isGithubNonEmptyAndEqual = isBothGithubNonEmpty && otherPerson.getGithub().equals(getGithub());
+
+
         return otherPerson != null
-                && (otherPerson.getEmail().equals(getEmail())
-                || otherPerson.getPhone().equals(getPhone())
-                || otherPerson.getTelegram().equals(getTelegram())
-                || otherPerson.getGithub().equals(getGithub()));
+                && (isEmailEqual
+                || isPhoneEqual
+                || isTelegramNonEmptyAndEqual
+                || isGithubNonEmptyAndEqual);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Telegram.java
+++ b/src/main/java/seedu/address/model/person/Telegram.java
@@ -53,6 +53,12 @@ public class Telegram {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true is the Telegram ID is empty.
+     */
+    public boolean isEmpty() {
+        return telegramId.isEmpty();
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
Closes #41 

Previously, the check would indicate 2 Persons are the same if both their Telegrams are empty, or both their Githubs are empty.

With this fix, the check would not consider factor in the Telegram or Github values if either of the Persons have empty values for those fields.