### PR TITLE
Fix bug where contacts wouldn't get loaded

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -96,7 +96,7 @@ class JsonAdaptedPerson {
         final ClassGroup modelClassGroup = new ClassGroup(classGroup);
 
         final Optional<Telegram> modelTelegram;
-        if (telegram == null) {
+        if (telegram == null || telegram.isEmpty()) {
             modelTelegram = Optional.of(Telegram.EMPTY);
         } else if (!Telegram.isValidTelegram(telegram)) {
             throw new IllegalValueException(Telegram.MESSAGE_CONSTRAINTS);
@@ -105,7 +105,7 @@ class JsonAdaptedPerson {
         }
 
         final Optional<Github> modelGithub;
-        if (github == null) {
+        if (github == null || github.isEmpty()) {
             modelGithub = Optional.of(Github.EMPTY);
         } else if (!Github.isValidGithub(github)) {
             throw new IllegalValueException(Github.MESSAGE_CONSTRAINTS);


### PR DESCRIPTION
This fixes the bug where any contact who doesn't have a Github or Telegram wouldn't get persisted in the storage. This was because the person would fail the validity check because their telegram or github strings were empty. Updated it so that empty strings would return Telegram.EMPTY and Github.EMPTY instead.