### PR TITLE
Change workflow to only run on team fork

### DIFF
--- a/.github/workflows/telegram.yml
+++ b/.github/workflows/telegram.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
 
   build:
+    if: github.repository == 'AY2324S2-CS2103T-F14-3/tp'
     name: Build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR makes it so that the telegram message action will only run on the team's fork, and not your own individual forks.