### PR TITLE
Fix side panel to update correctly after every command execution

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -34,6 +35,18 @@ public interface Logic {
     ObservableList<Person> getFilteredPersonList();
 
     /**
+     * Retrieves the last viewed {@link Person} instance.
+     * <p>
+     * This method returns an {@link Optional} which will be empty if no person has
+     * been viewed last, or will contain a reference to the {@link Person} object
+     * that was last viewed.
+     *
+     * @return an {@link Optional} containing the last viewed {@link Person} if such
+     *     a person exists, or an empty {@link Optional} if no person has been viewed last.
+     */
+    Optional<Person> getLastViewedPerson();
+
+    /**
      * Returns the user prefs' address book file path.
      */
     Path getAddressBookFilePath();
@@ -47,10 +60,4 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
-
-    /**
-     * Retrieves the last viewed person after a successful "view" command.
-     * @return The last viewed person, or null if no view command has been executed yet.
-     */
-    Person getLastViewedPerson();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -33,7 +34,6 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
-    private Person lastViewedPerson;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -51,11 +51,6 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
-
-        if (command instanceof ViewCommand) {
-            int index = ((ViewCommand) command).getTargetIndex().getZeroBased();
-            lastViewedPerson = model.getFilteredPersonList().get(index);
-        }
 
         try {
             storage.saveAddressBook(model.getAddressBook());
@@ -79,6 +74,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public Optional<Person> getLastViewedPerson() {
+        return model.getLastViewedPerson();
+    }
+
+    @Override
     public Path getAddressBookFilePath() {
         return model.getAddressBookFilePath();
     }
@@ -91,10 +91,5 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
-    }
-
-    @Override
-    public Person getLastViewedPerson() {
-        return lastViewedPerson;
     }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -11,7 +11,6 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Optional;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -42,7 +43,19 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        updateLastViewedPersonIfNecessary(personToDelete, model);
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+    }
+
+    private void updateLastViewedPersonIfNecessary(Person personToDelete, Model model) {
+        Optional<Person> lastViewedPerson = model.getLastViewedPerson();
+        if (lastViewedPerson.isEmpty()) {
+            return;
+        }
+        if (lastViewedPerson.get().equals(personToDelete)) {
+            model.resetLastViewedPerson();
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.Optional;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -49,13 +49,9 @@ public class DeleteCommand extends Command {
     }
 
     private void updateLastViewedPersonIfNecessary(Person personToDelete, Model model) {
-        Optional<Person> lastViewedPerson = model.getLastViewedPerson();
-        if (lastViewedPerson.isEmpty()) {
-            return;
-        }
-        if (lastViewedPerson.get().equals(personToDelete)) {
-            model.resetLastViewedPerson();
-        }
+        model.getLastViewedPerson()
+                .filter(lastViewedPerson -> lastViewedPerson.equals(personToDelete))
+                .ifPresent(lastViewedPerson -> model.resetLastViewedPerson());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GITHUB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -80,7 +80,6 @@ public class EditCommand extends Command {
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
-
         updatePerson(personToEdit, editedPerson, model);
         updateLastViewedPersonIfNecessary(personToEdit, editedPerson, model);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
@@ -96,7 +95,6 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_FIELD);
         }
         model.addPersonKeepFilter(editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     private void updateLastViewedPersonIfNecessary(Person personToEdit, Person editedPerson, Model model) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -81,6 +81,12 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
+        updatePerson(personToEdit, editedPerson, model);
+        updateLastViewedPersonIfNecessary(personToEdit, editedPerson, model);
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+    }
+
+    private void updatePerson(Person personToEdit, Person editedPerson, Model model) throws CommandException {
         if (personToEdit.equals(editedPerson)) {
             throw new CommandException(MESSAGE_NO_CHANGE);
         }
@@ -89,10 +95,18 @@ public class EditCommand extends Command {
             model.addPersonKeepFilter(personToEdit);
             throw new CommandException(MESSAGE_DUPLICATE_FIELD);
         }
-
         model.addPersonKeepFilter(editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+    }
+
+    private void updateLastViewedPersonIfNecessary(Person personToEdit, Person editedPerson, Model model) {
+        Optional<Person> lastViewedPerson = model.getLastViewedPerson();
+        if (lastViewedPerson.isEmpty()) {
+            return;
+        }
+        if (lastViewedPerson.get().equals(personToEdit)) {
+            model.updateLastViewedPerson(editedPerson);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -97,13 +97,9 @@ public class EditCommand extends Command {
     }
 
     private void updateLastViewedPersonIfNecessary(Person personToEdit, Person editedPerson, Model model) {
-        Optional<Person> lastViewedPerson = model.getLastViewedPerson();
-        if (lastViewedPerson.isEmpty()) {
-            return;
-        }
-        if (lastViewedPerson.get().equals(personToEdit)) {
-            model.updateLastViewedPerson(editedPerson);
-        }
+        model.getLastViewedPerson()
+                .filter(lastViewedPerson -> lastViewedPerson.equals(personToEdit))
+                .ifPresent(lastViewedPerson -> model.updateLastViewedPerson(editedPerson));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -51,6 +51,7 @@ public class ViewCommand extends Command {
         }
 
         Person personToView = lastShownList.get(targetIndex.getZeroBased());
+        model.updateLastViewedPerson(personToView);
         return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, Messages.format(personToView)));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,11 +1,14 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The API of the Model component.
@@ -83,4 +86,31 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Retrieves the last viewed {@link Person} instance.
+     * <p>
+     * This method returns an {@link Optional} which will be empty if no person has
+     * been viewed last, or will contain a reference to the {@link Person} object
+     * that was last viewed.
+     *
+     * @return an {@link Optional} containing the last viewed {@link Person} if such
+     *     a person exists, or an empty {@link Optional} if no person has been viewed last.
+     */
+    Optional<Person> getLastViewedPerson();
+
+    /**
+     * Resets the information about the last viewed person.
+     */
+    void resetLastViewedPerson();
+
+    /**
+     * Updates the record of the last viewed person to the specified {@link Person}.
+     * <p>
+     * This method sets the internally tracked last viewed person to the provided
+     * {@link Person} instance.
+     *
+     * @param p the {@link Person} instance to set as the last viewed person; cannot be {@code null}.
+     */
+    void updateLastViewedPerson(Person p);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,8 +8,6 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * The API of the Model component.
  */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private Optional<Person> lastViewedPerson;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        lastViewedPerson = Optional.empty();
     }
 
     public ModelManager() {
@@ -126,6 +129,24 @@ public class ModelManager implements Model {
         filteredPersons.setPredicate(predicate);
     }
 
+    //=========== Last Viewed Person Accessors =============================================================
+
+    @Override
+    public Optional<Person> getLastViewedPerson() {
+        return lastViewedPerson;
+    }
+
+    @Override
+    public void resetLastViewedPerson() {
+        lastViewedPerson = Optional.empty();
+    }
+
+    @Override
+    public void updateLastViewedPerson(Person p) {
+        requireNonNull(p);
+        lastViewedPerson = Optional.of(p);
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -142,5 +163,4 @@ public class ModelManager implements Model {
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredPersons.equals(otherModelManager.filteredPersons);
     }
-
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -186,12 +187,12 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            // If it's a successful view command, display the person in the SidePanel
-            if (commandResult.getFeedbackToUser().startsWith("View Person:")) {
-                Person viewedPerson = logic.getLastViewedPerson();
-                if (viewedPerson != null) {
-                    sidePanel.displayPerson(viewedPerson);
-                }
+            // If there is a last viewed Person, display the person in the SidePanel
+            Optional<Person> lastViewedPerson = logic.getLastViewedPerson();
+            if (lastViewedPerson.isEmpty()) {
+                sidePanel.resetDetails();
+            } else {
+                sidePanel.displayPerson(lastViewedPerson.get());
             }
 
             if (commandResult.isShowHelp()) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -187,7 +187,6 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            // If there is a last viewed Person, display the person in the SidePanel
             Optional<Person> lastViewedPerson = logic.getLastViewedPerson();
             lastViewedPerson.ifPresentOrElse(sidePanel::displayPerson, sidePanel::resetDetails);
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -189,11 +189,7 @@ public class MainWindow extends UiPart<Stage> {
 
             // If there is a last viewed Person, display the person in the SidePanel
             Optional<Person> lastViewedPerson = logic.getLastViewedPerson();
-            if (lastViewedPerson.isEmpty()) {
-                sidePanel.resetDetails();
-            } else {
-                sidePanel.displayPerson(lastViewedPerson.get());
-            }
+            lastViewedPerson.ifPresentOrElse(sidePanel::displayPerson, sidePanel::resetDetails);
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/SidePanel.java
+++ b/src/main/java/seedu/address/ui/SidePanel.java
@@ -84,7 +84,7 @@ public class SidePanel extends UiPart<Region> {
     /**
      * Clears all the details from the side panel.
      */
-    private void resetDetails() {
+    public void resetDetails() {
         nameLabel.setText("");
         classGroupLabel.setText("");
         emailLabel.setText("");

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -155,6 +156,21 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Optional<Person> getLastViewedPerson() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void resetLastViewedPerson() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateLastViewedPerson(Person p) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -42,6 +42,22 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_validDeleteLastViewedPerson_success() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.updateLastViewedPerson(personToDelete);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+        expectedModel.resetLastViewedPerson();
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -103,6 +103,24 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_editLastViewedPerson_success() {
+        Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.updateLastViewedPerson(personToEdit);
+        Person editedPerson = new PersonBuilder(personToEdit).withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateLastViewedPerson(editedPerson);
+        expectedModel.deletePerson(model.getFilteredPersonList().get(0));
+        expectedModel.addPersonKeepFilter(editedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -95,8 +95,9 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
         expectedModel.deletePerson(model.getFilteredPersonList().get(0));
-        expectedModel.addPerson((editedPerson));
+        expectedModel.addPersonKeepFilter(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
Previously, the side panel will update only when a View Command is executed. This could lead to bugs where `update` or `delete` commands do not update the side panel accordingly.

Now, the execution of every command will lead cause side panel to update based on `lastViewedPerson`. `View`, `update`, `delete` will update `lastViewedPerson` causing the side panel to update correctly.