### PR TITLE
Update add note command to follow edit command format

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDICES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import java.util.List;
@@ -25,13 +24,15 @@ public class AddNoteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds a note to a person identified by the index number used in the displayed person list.\n"
+            + "Note may only contain alphanumeric characters basic punctuation "
+            + "(periods, commas, exclamation marks, question marks)\n"
             + "Parameters:"
-            + PREFIX_INDICES + "INDEX (must be a positive integer) "
+            + " INDEX (must be a positive integer) "
             + PREFIX_NOTE + "NOTE\n"
             + "Example: "
             + COMMAND_WORD + " "
-            + PREFIX_INDICES + "1 "
-            + PREFIX_NOTE + "Asked a question regarding test cases";
+            + "1 "
+            + PREFIX_NOTE + "Asked a question regarding test cases.";
 
     public static final String MESSAGE_SUCCESS = "New note added to %1$s.\nNote: %2$s";
     private static final Logger logger = Logger.getLogger(AddNoteCommand.class.getName());

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDICES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import java.util.stream.Stream;
@@ -22,16 +22,23 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddNoteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_INDICES, PREFIX_NOTE);
-        if (!arePrefixesPresent(argMultimap, PREFIX_INDICES, PREFIX_NOTE)
-                || !argMultimap.getPreamble().isEmpty()) {
+                ArgumentTokenizer.tokenize(args, PREFIX_NOTE);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NOTE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDICES, PREFIX_NOTE);
-
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDICES).get());
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NOTE);
         Note note = ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get());
 
         return new AddNoteCommand(index, note);

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -2,18 +2,28 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Note;
 
 public class AddNoteCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE);
 
     private AddNoteCommandParser parser = new AddNoteCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Index expectedIndex = Index.fromOneBased(1);
+        Note expectedNote = new Note("very hardworking!!!");
+        assertParseSuccess(parser, "1 note/very hardworking!!!", new AddNoteCommand(expectedIndex, expectedNote));
+    }
 
     @Test
     public void parse_missingArgument_throwParseException() {
@@ -23,7 +33,7 @@ public class AddNoteCommandParserTest {
 
     @Test
     public void parse_invalidIndex_throwParseException() {
-        assertThrows(ParseException.class, () -> parser.parse("a hardworking"));
+        assertThrows(ParseException.class, () -> parser.parse("a note/hardworking"));
     }
 
     @Test
@@ -33,6 +43,6 @@ public class AddNoteCommandParserTest {
 
     @Test
     public void parse_zeroBasedIndex_throwParseException() {
-        assertThrows(ParseException.class, () -> parser.parse("0 hardworking"));
+        assertThrows(ParseException.class, () -> parser.parse("0 note/hardworking"));
     }
 }


### PR DESCRIPTION
Previously the add note command was:
`an i/1 note/message 1`

Now, it is:
`an 1 note/message 1`.

This makes it consistent with the edit command format.
